### PR TITLE
Updated register method to comply to the new specifications of Larave…

### DIFF
--- a/src/CsvServiceProvider.php
+++ b/src/CsvServiceProvider.php
@@ -7,7 +7,7 @@ class CsvServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->app->bindshared('csv', function()
+        $this->app->singleton('csv', function()
         {
             return new  CsvDownload;
         });


### PR DESCRIPTION
This package would be available for Laravel 5.2 since they deprecated the bindshared() method.

> The service container's bindShared method has been deprecated in favor of the singleton method.[Upgrade guide (under Deprecations)](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0)